### PR TITLE
More Model Functions

### DIFF
--- a/KotorMessageInjector/Adapter.cs
+++ b/KotorMessageInjector/Adapter.cs
@@ -236,6 +236,47 @@ namespace KotorMessageInjector
             return gob;
         }
 
+        public static void MoveModel(IntPtr pHandle, uint gob, float x, float y, float z)
+        {
+            var om = new ObjManager(pHandle);
+            var i = new Injector(pHandle);
+            var funcLibrary = getFuncLibrary(pHandle);
+
+            _ = i.runFunction(new RemoteFunction(funcLibrary[Function.Gob_SetPosition], false)
+                .setThis(gob)
+                .addParam(om.createVector(0, 0, 0))
+                .addParam(x)
+                .addParam(y)
+                .addParam(z));
+        }
+
+        // Takes a Yaw, Pitch, and Roll in Degrees. And Converts it to Quaternion Orientation
+        // Gob_SetOrientation could theorhetically also be used for skews if you feel like doing the math
+        public static void RotateModel(IntPtr pHandle, uint gob, float yaw, float pitch, float roll)
+        {
+            var om = new ObjManager(pHandle);
+            var i = new Injector(pHandle);
+            var funcLibrary = getFuncLibrary(pHandle);
+
+            uint orientation = om.createQuaternion(0, 0, 0, 0);
+
+            _ = i.runFunction(new RemoteFunction(funcLibrary[Function.YawPitchRoll], false)
+                .addParam(orientation)
+                .addParam(yaw)
+                .addParam(pitch)
+                .addParam(roll));
+
+            var (w, x, y, z) = readQuaternion(pHandle, (IntPtr)orientation);
+
+            _ = i.runFunction(new RemoteFunction(funcLibrary[Function.Gob_SetOrientation], false)
+                .setThis(gob)
+                .addParam(om.createQuaternion(0, 0, 0, 0))
+                .addParam(w)
+                .addParam(x)
+                .addParam(y)
+                .addParam(z));
+        }
+
         public static (float, float, float) Normalize(float x, float y, float z)
         {
             var magnitude = Math.Sqrt(x * x + y * y + z * z);
@@ -267,6 +308,16 @@ namespace KotorMessageInjector
                 .addParam(0));
         }
 
+        public static void DeleteModel(IntPtr pHandle, uint gob)
+        {
+            var i = new Injector(pHandle);
+            var funcLibrary = getFuncLibrary(pHandle);
+
+            _ = i.runFunction(new RemoteFunction(funcLibrary[Function.Gob_AttachToScene], false)
+                .setThis(gob)
+                .addParam(0));
+        }
+        
         #endregion
     }
 }

--- a/KotorMessageInjector/KotorHelpers.cs
+++ b/KotorMessageInjector/KotorHelpers.cs
@@ -404,5 +404,20 @@ namespace KotorMessageInjector
             byte[] data = new byte[4] { (byte)(value & 0xFF), (byte)((value >> 8) & 0xFF), (byte)((value >> 16) & 0xFF), (byte)((value >> 24) & 0xFF) };
             WriteProcessMemory(processHandle, addr, data, 4, out outPtr);
         }
+
+        public static (float, float, float, float) readQuaternion(IntPtr processHandle, IntPtr addr)
+        {
+            byte[] outBytes = new byte[16];
+            ReadProcessMemory(processHandle, addr, outBytes, 16, out _);
+
+            return
+            (
+                BitConverter.ToSingle(outBytes, 0),
+                BitConverter.ToSingle(outBytes, 4),
+                BitConverter.ToSingle(outBytes, 8),
+                BitConverter.ToSingle(outBytes, 12)
+            );
+        }
+
     }
 }

--- a/KotorMessageInjector/ObjManager.cs
+++ b/KotorMessageInjector/ObjManager.cs
@@ -132,5 +132,25 @@ namespace KotorMessageInjector
             return dataPointer;
         }
 
+        public uint createQuaternion(float w, float x, float y, float z)
+        {
+            uint dataPointer = (uint)remoteIndex;
+
+            List<byte> data = new List<byte>();
+            data.AddRange(GetBytes(w));
+            data.AddRange(GetBytes(x));
+            data.AddRange(GetBytes(y));
+            data.AddRange(GetBytes(z));
+
+            remoteSize += (uint)data.Count;
+            checkForOverflow();
+
+            UIntPtr bytesWritten;
+            WriteProcessMemory(processHandle, remoteIndex, data.ToArray(), (uint)data.Count, out bytesWritten);
+            remoteIndex += data.Count;
+
+            return dataPointer;
+        }
+
     }
 }

--- a/KotorMessageInjector/RemoteFunctionLibrary.cs
+++ b/KotorMessageInjector/RemoteFunctionLibrary.cs
@@ -23,11 +23,13 @@ namespace KotorMessageInjector
         Gob_SetIllumination,
         Gob_SetObjectScale,
         Gob_SetPosition,
+        Gob_SetOrientation,
         Gob_SetScene,
         Gob_TurnOffShadows,
         NewCAurObject,
         Operator_New,
         Scene_AddObject,
+        YawPitchRoll,
     }
 
     public static class RemoteFunctionLibrary
@@ -49,6 +51,7 @@ namespace KotorMessageInjector
             {Function.NewCAurObject, 0x00449cc0},
             {Function.Scene_AddObject, 0x00458bd0},
             {Function.Gob_SetPosition, 0x0043f0c0},
+            {Function.Gob_SetOrientation, 0x0043f0f0},
             {Function.Gob_SetScene, 0x0043f200},
             {Function.Gob_AttachToScene, 0x0044f7c0},
 
@@ -58,6 +61,8 @@ namespace KotorMessageInjector
             {Function.Gob_ReplaceTexture, 0x00446520},
             {Function.Gob_TurnOffShadows, 0x00449a50},
             {Function.Gob_SetIllumination, 0x0043eea0},
+
+            {Function.YawPitchRoll, 0x004acac0},
         };
 
         public static Dictionary<string, uint> kotor1Functions = new Dictionary<string, uint>()
@@ -97,6 +102,17 @@ namespace KotorMessageInjector
             {Function.CServerExoApp_SetMoveToModulePending, 0x0064b870},
             {Function.CFactionManager_GetFaction, 0x007ef020},
             {Function.CSWSFaction_AddMember, 0x007e4850},
+
+            {Function.NewCAurObject, 0x008548b0},
+            {Function.Gob_SetPosition, 0x00853a20},
+            {Function.Gob_SetOrientation, 0x00853a70},
+            {Function.Gob_AttachToScene, 0x0085f680},
+            {Function.Gob_SetColorShifting, 0x0084ed30},
+            {Function.Gob_SetObjectScale, 0x00855830},
+            {Function.Gob_TurnOffShadows, 0x0084be30},
+            {Function.Gob_SetIllumination, 0x0084ed90},
+
+            {Function.YawPitchRoll, 0x0080d4b0},
         };
 
         public static Dictionary<string, uint> kotor2Functions = new Dictionary<string, uint>()
@@ -136,6 +152,17 @@ namespace KotorMessageInjector
             {Function.CServerExoApp_SetMoveToModulePending, 0x0051be50},
             {Function.CFactionManager_GetFaction, 0x00664490},
             {Function.CSWSFaction_AddMember, 0x006d3330},
+
+            {Function.NewCAurObject, 0x00462320},
+            {Function.Gob_SetPosition, 0x00461490},
+            {Function.Gob_SetOrientation, 0x004614e0},
+            {Function.Gob_AttachToScene, 0x0046d440},
+            {Function.Gob_SetColorShifting, 0x0045c750},
+            {Function.Gob_SetObjectScale, 0x00463340},
+            {Function.Gob_TurnOffShadows, 0x00459850},
+            {Function.Gob_SetIllumination, 0x0045c7b0},
+
+            {Function.YawPitchRoll, 0x00515620},
         };
 
         public static Dictionary<string, uint> kotor2SteamFunctions = new Dictionary<string, uint>()

--- a/testApp/Examples.cs
+++ b/testApp/Examples.cs
@@ -297,6 +297,19 @@ namespace testApp
             return gob;
         }
 
+        public static void deleteModel(IntPtr pHandle, uint gob)
+        {
+            ObjManager om = new ObjManager(pHandle);
+
+            Injector i = new Injector(pHandle);
+
+            Dictionary<string, uint> funcLibrary = getFunctionLibrary(pHandle);
+
+            RemoteFunction rf = new RemoteFunction(funcLibrary["Gob::AttachToScene"], false);
+            rf.setThis(gob);
+            rf.addParam(0);
+            i.runFunction(rf);
+        }
         public static (float, float, float) normalize(float x, float y, float z)
         {
             double magnitude = Math.Sqrt(x * x + y * y + z * z);

--- a/testApp/Program.cs
+++ b/testApp/Program.cs
@@ -156,7 +156,19 @@ namespace testApp
             );
             Examples.colorizeModel(pHandle, gob, 1f, 0f, 0f);
 
-            //Console.ReadKey();
+            //uint gob = Examples.drawModel
+            //(
+            //    pHandle, "gi_sound_pos", 1f,
+            //    112.5f, 154.0f, 0.5f
+            //);
+
+            //Examples.colorizeModel(pHandle, gob, 0f, 1f, 0f);
+
+            Adapter.RotateModel(pHandle, gob, 0.0f, 0.0f, 0.0f);
+
+            Console.ReadKey();
+
+            Examples.deleteModel(pHandle, gob);
         }
     }
 }


### PR DESCRIPTION
## Adapter
- `DeleteModel` function, which deletes the model reference by `gob`
- `RotateModel` function, which rotates the model reference by `gob` to a Yaw, Pitch, and Roll in degrees
- `MoveModel` function, which moves the model reference by `gob` to x, y, z

## Helpers
- `readQuaternion`, which reads a 16 byte quaternion struct from kotor's memory

## ObjManager
- `createQuaternion`, which creates a reference-able 16 byte quaternion struct in kotor's memory

## Func Library
- Kotor 2 support for model drawing
- `YawPitchRoll` function
- `Gob::SetOrientation`function