### PR TITLE
Adapter clear and set feats methods

### DIFF
--- a/KotorMessageInjector/Adapter.cs
+++ b/KotorMessageInjector/Adapter.cs
@@ -2,6 +2,8 @@
 using static KotorMessageInjector.Message;
 using System;
 using System.Runtime.InteropServices;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace KotorMessageInjector
 {
@@ -431,6 +433,34 @@ namespace KotorMessageInjector
             _ = i.runFunction(new RemoteFunction(funcLibrary[Function.CSWSCreatureStats_AddFeat], false)
                 .setThis(creatureStats)
                 .addParam((int)feat));
+        }
+
+        public static void ClearCreatureFeats(IntPtr pHandle, uint serverCreature)
+        {
+            var i = new Injector(pHandle);
+            var funcLibrary = getFuncLibrary(pHandle);
+
+            var creatureStats = getCreatureStats(pHandle, serverCreature);
+
+            _ = i.runFunction(new RemoteFunction(funcLibrary[Function.CSWSCreatureStats_ClearFeats], false)
+                .setThis(creatureStats));
+        }
+
+        public static void SetCreatureFeats(IntPtr pHandle, uint serverCreature, List<FEATS> feats)
+        {
+            var i = new Injector(pHandle);
+            var funcLibrary = getFuncLibrary(pHandle);
+            var creatureStats = getCreatureStats(pHandle, serverCreature);
+
+            _ = i.runFunction(new RemoteFunction(funcLibrary[Function.CSWSCreatureStats_ClearFeats], false)
+                .setThis(creatureStats));
+
+            foreach (var feat in feats)
+            {
+                _ = i.runFunction(new RemoteFunction(funcLibrary[Function.CSWSCreatureStats_AddFeat], false)
+                    .setThis(creatureStats)
+                    .addParam((int)feat));
+            }
         }
 
         public static void AddCreatureClass(IntPtr pHandle, uint serverCreature, CLASSES newClass)

--- a/KotorMessageInjector/KotorHelpers_Constants.cs
+++ b/KotorMessageInjector/KotorHelpers_Constants.cs
@@ -45,12 +45,12 @@ namespace KotorMessageInjector
         [Flags]
         public enum CLIENT_OBJECT_UPDATE_FLAGS : uint
         {
-            POSITION = 0b00000000000000000000000000000001,
-            ORIENTATION = 0b00000000000000000000000000000010,
-            ANIMATION = 0b00000000000000000000000000000100,
-            VFX = 0b00000000000000000000000000001000,
+            POSITION           = 0b00000000000000000000000000000001,
+            ORIENTATION        = 0b00000000000000000000000000000010,
+            ANIMATION          = 0b00000000000000000000000000000100,
+            VFX                = 0b00000000000000000000000000001000,
             OBJECT_INTERACTION = 0b00000000000000000000000000010000, //Specific to Doors, Placeables, and Triggers
-            PORTRAIT = 0b00000000000000000000000000100000,
+            PORTRAIT           = 0b00000000000000000000000000100000,
             // Below are specific to Creatures
             // TODO: Fill these out
 
@@ -58,23 +58,23 @@ namespace KotorMessageInjector
 
         public enum GAME_OBJECT_TYPES : byte
         {
-            OBJECT_0 = 0,
-            OBJECT_1 = 1,
-            OBJECT_2 = 2,
-            MODULE = 3,
-            AREA = 4,
-            CREATURE = 5,
-            ITEM = 6,
-            TRIGGER = 7,
-            PROJECTILE = 8,
-            PLACEABLE = 9,
-            DOOR = 10,
+            OBJECT_0     = 0,
+            OBJECT_1     = 1,
+            OBJECT_2     = 2,
+            MODULE       = 3,
+            AREA         = 4,
+            CREATURE     = 5,
+            ITEM         = 6,
+            TRIGGER      = 7,
+            PROJECTILE   = 8,
+            PLACEABLE    = 9,
+            DOOR         = 10,
             AREAOFEFFECT = 11,
-            WAYPOINT = 12,
-            ENCOUNTER = 13,
-            STORE = 14,
-            OBJECT_f = 15,
-            SOUND = 16,
+            WAYPOINT     = 12,
+            ENCOUNTER    = 13,
+            STORE        = 14,
+            OBJECT_f     = 15,
+            SOUND        = 16,
         }
 
         public enum ATTRIBUTES
@@ -99,6 +99,7 @@ namespace KotorMessageInjector
             TREAT_INJURY = 7,
         }
 
+        public const ushort FIRST_KOTOR_2_FEAT = 125;
         public enum FEATS : ushort
         {
             UNDEFINED = 0,
@@ -348,6 +349,7 @@ namespace KotorMessageInjector
 
         }
 
+        public const byte FIRST_KOTOR_2_CLASS = 9;
         public enum CLASSES : byte
         {
             SOLDIER = 0,
@@ -370,6 +372,7 @@ namespace KotorMessageInjector
             SITH_ASSASSIN = 16
         }
 
+        public const int FIRST_KOTOR_2_SPELL = 131;
         public enum SPELLS : int
         {
             FORCE_POWER_MASTER_ALTER_XXX = 0,

--- a/KotorMessageInjector/ProcessAPI.cs
+++ b/KotorMessageInjector/ProcessAPI.cs
@@ -335,5 +335,10 @@ namespace KotorMessageInjector
             uint dwSize,
             uint flNewProtect,
             out uint lpflOldProtect);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool GetHandleInformation(
+            IntPtr hProcess,
+            out uint lpdwFlags);
     }
 }


### PR DESCRIPTION
I added two adapter methods that handle clearing feats and resetting to a specified list of feats. I also added constants for the first Kotor 2 value in each enum for use in the Visualizer.