### PR TITLE
Various Scene functions

### DIFF
--- a/KotorMessageInjector/Adapter.cs
+++ b/KotorMessageInjector/Adapter.cs
@@ -808,6 +808,74 @@ namespace KotorMessageInjector
                 .addParam((int)npc)
                 .addParam(influence));
         }
+
+        /// <summary>
+        /// Enables Fog in the current scene.
+        /// </summary>
+        /// <param name="pHandle">The running kotor process</param>
+        /// <param name="rangeStart">The distance from the camera the Fog gradient will start</param>
+        /// <param name="rangeEnd">The distance fromt the camera the Fog gradient will end</param>
+        /// <param name="colorR">Red component of the fog color</param>
+        /// <param name="colorG">Green Component of the fog color</param>
+        /// <param name="colorB">Blue component of the fog color</param>
+        /// <remarks>
+        /// The fog is fully transparent at `rangeStart` from the camera, and opaque at `rangeEnd` from the camera.
+        /// If `rangeEnd` < `rangeStart`, the fog will be dense near the camera, and fade out at further distances.
+        /// If `rangeEnd` = `rangeStart`, the behavior is undefined, and graphical bugs may occur
+        /// </remarks>
+        public static void SetSceneFogOn(IntPtr pHandle, float rangeStart, float rangeEnd, float colorR = 0.5f, float colorG = 0.5f, float colorB = 0.5f)
+        {
+            var i = new Injector(pHandle);
+            var funcLibrary = getFuncLibrary(pHandle);
+            var om = new ObjManager(pHandle);
+
+            uint scene = getCurrentScene(pHandle);
+            var color = om.createVector(colorR, colorG, colorB);
+
+            i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_SetFog])
+                .setThis(scene)
+                .addParam(1));
+
+            i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_SetFogRange])
+               .setThis(scene)
+               .addParam(rangeStart)
+               .addParam(rangeEnd));
+
+            i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_SetFogColor])
+               .setThis(scene)
+               .addParam(color));
+        }
+
+        public static void SetSceneFogOff(IntPtr pHandle)
+        {
+            var i = new Injector(pHandle);
+            var funcLibrary = getFuncLibrary(pHandle);
+
+            uint scene = getCurrentScene(pHandle);
+
+            i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_SetFog])
+                .setThis(scene)
+                .addParam(0));
+        }
+
+        public static void SetVisibilityGraph(IntPtr pHandle, bool on) 
+        {
+            var i = new Injector(pHandle);
+            var funcLibrary = getFuncLibrary(pHandle);
+
+            uint scene = getCurrentScene(pHandle);
+
+            if (on)
+            {
+                i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_EnableVisibilityGraph])
+                    .setThis(scene));
+            }
+            else
+            {
+                i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_DisableVisibilityGraph])
+                   .setThis(scene));
+            }
+        }
         #endregion
     }
 }

--- a/KotorMessageInjector/KotorHelpers.cs
+++ b/KotorMessageInjector/KotorHelpers.cs
@@ -496,5 +496,87 @@ namespace KotorMessageInjector
 
             WriteProcessMemory(processHandle, (IntPtr)(creatureStats + offset), inBytes, 4, out _);
         }
+
+        public static (float h, float s, float b) RgbToHsb(float r, float g, float b)
+        {
+            float max = Math.Max(r, Math.Max(g, b));
+            float min = Math.Min(r, Math.Min(g, b));
+            float delta = max - min;
+
+            // Calculate Brightness (Value)
+            float brightness = max;
+
+            // Calculate Saturation
+            float saturation = max == 0 ? 0 : delta / max;
+
+            // Calculate Hue
+            float hue = 0;
+            if (delta != 0)
+            {
+                if (max == r)
+                    hue = ((g - b) / delta) % 6;
+                else if (max == g)
+                    hue = (b - r) / delta + 2;
+                else if (max == b)
+                    hue = (r - g) / delta + 4;
+
+                hue *= 60; // Convert to degrees (0-360)
+
+                if (hue < 0)
+                    hue += 360;
+            }
+
+            // Normalize hue to 0-1 range
+            hue = hue / 360.0f;
+
+            return (hue, saturation, brightness);
+        }
+
+        public static (float r, float g, float b) HsbToRgb(float h, float s, float b)
+        {
+            // Convert hue from 0-1 to 0-360 for calculations
+            float hue = h * 360.0f;
+
+            // Normalize hue to 0-360 range
+            hue = hue % 360;
+            if (hue < 0) hue += 360;
+
+            float c = b * s; // Chroma
+            float x = c * (1 - Math.Abs((hue / 60) % 2 - 1));
+            float m = b - c;
+
+            float r1, g1, b1;
+
+            if (hue >= 0 && hue < 60)
+            {
+                r1 = c; g1 = x; b1 = 0;
+            }
+            else if (hue >= 60 && hue < 120)
+            {
+                r1 = x; g1 = c; b1 = 0;
+            }
+            else if (hue >= 120 && hue < 180)
+            {
+                r1 = 0; g1 = c; b1 = x;
+            }
+            else if (hue >= 180 && hue < 240)
+            {
+                r1 = 0; g1 = x; b1 = c;
+            }
+            else if (hue >= 240 && hue < 300)
+            {
+                r1 = x; g1 = 0; b1 = c;
+            }
+            else // hue >= 300 && hue < 360
+            {
+                r1 = c; g1 = 0; b1 = x;
+            }
+
+            float r = r1 + m;
+            float g = g1 + m;
+            float b_final = b1 + m;
+
+            return (r, g, b_final);
+        }
     }
 }

--- a/KotorMessageInjector/ObjManager.cs
+++ b/KotorMessageInjector/ObjManager.cs
@@ -150,6 +150,16 @@ namespace KotorMessageInjector
             return dataPointer;
         }
 
+        public void setVector(IntPtr dataPointer, float x, float y, float z)
+        {
+            List<byte> data = new List<byte>();
+            data.AddRange(GetBytes(x));
+            data.AddRange(GetBytes(y));
+            data.AddRange(GetBytes(z));
+
+            WriteProcessMemory(processHandle, dataPointer, data.ToArray(), (uint)data.Count, out _);
+        }
+
         public uint createQuaternion(float w, float x, float y, float z)
         {
             uint dataPointer = (uint)remoteIndex;

--- a/KotorMessageInjector/RemoteFunctionLibrary.cs
+++ b/KotorMessageInjector/RemoteFunctionLibrary.cs
@@ -59,15 +59,11 @@ namespace KotorMessageInjector
         CClientExoApp_GetObjectName,
         CSWPartyTable_GetInfluence,
         CSWPartyTable_SetInfluence,
-        Scene_SetBlindLights,
         Scene_SetFog,
         Scene_SetFogColor,
         Scene_SetFogRange,
-        Scene_SetSceneFocus,
         Scene_EnableVisibilityGraph,
         Scene_DisableVisibilityGraph,
-        Scene_EnableAnimations,
-        Scene_DisableAnimations
     }
 
     public static class RemoteFunctionLibrary
@@ -135,15 +131,11 @@ namespace KotorMessageInjector
 
             {Function.CClientExoApp_GetObjectName, 0x005ed350},
 
-            {Function.Scene_SetBlindLights, 0x0044fd50},
             {Function.Scene_SetFog, 0x00458b30},
             {Function.Scene_SetFogColor, 0x00458b40},
             {Function.Scene_SetFogRange, 0x00458b80},
-            {Function.Scene_SetSceneFocus, 0x00458ba0},
             {Function.Scene_EnableVisibilityGraph, 0x0044f7e0}, //Room Culling
             {Function.Scene_DisableVisibilityGraph, 0x0044f800},
-            {Function.Scene_EnableAnimations, 0x0044f3a0}, //Animations when the game is/isn't in focus
-            {Function.Scene_DisableAnimations, 0x0044f3b0},
 
         };
 
@@ -208,6 +200,12 @@ namespace KotorMessageInjector
             {Function.CSWPartyTable_GetInfluence, 0x00700530},
             {Function.CSWPartyTable_SetInfluence, 0x00700560},
 
+            {Function.Scene_SetFog, 0x00857010},
+            {Function.Scene_SetFogColor, 0x00856850},
+            {Function.Scene_SetFogRange, 0x00857060},
+            {Function.Scene_EnableVisibilityGraph, 0x00861d50}, //Room Culling
+            {Function.Scene_DisableVisibilityGraph, 0x00861d80},
+
         };
 
         public static Dictionary<Function, uint> k2SteamFunctions = new Dictionary<Function, uint>()
@@ -270,6 +268,12 @@ namespace KotorMessageInjector
 
             {Function.CSWPartyTable_GetInfluence, 0x005fa9c0},
             {Function.CSWPartyTable_SetInfluence, 0x005fa9f0},
+
+            {Function.Scene_SetFog, 0x00464c30},
+            {Function.Scene_SetFogColor, 0x00464470},
+            {Function.Scene_SetFogRange, 0x00464c80},
+            {Function.Scene_EnableVisibilityGraph, 0x0046fb10}, //Room Culling
+            {Function.Scene_DisableVisibilityGraph, 0x0046fb40},
         };
     }
 }

--- a/KotorMessageInjector/RemoteFunctionLibrary.cs
+++ b/KotorMessageInjector/RemoteFunctionLibrary.cs
@@ -59,6 +59,15 @@ namespace KotorMessageInjector
         CClientExoApp_GetObjectName,
         CSWPartyTable_GetInfluence,
         CSWPartyTable_SetInfluence,
+        Scene_SetBlindLights,
+        Scene_SetFog,
+        Scene_SetFogColor,
+        Scene_SetFogRange,
+        Scene_SetSceneFocus,
+        Scene_EnableVisibilityGraph,
+        Scene_DisableVisibilityGraph,
+        Scene_EnableAnimations,
+        Scene_DisableAnimations
     }
 
     public static class RemoteFunctionLibrary
@@ -125,6 +134,16 @@ namespace KotorMessageInjector
             {Function.CGuiInGame_ShowItemCreateMenu, 0x0062d280},
 
             {Function.CClientExoApp_GetObjectName, 0x005ed350},
+
+            {Function.Scene_SetBlindLights, 0x0044fd50},
+            {Function.Scene_SetFog, 0x00458b30},
+            {Function.Scene_SetFogColor, 0x00458b40},
+            {Function.Scene_SetFogRange, 0x00458b80},
+            {Function.Scene_SetSceneFocus, 0x00458ba0},
+            {Function.Scene_EnableVisibilityGraph, 0x0044f7e0}, //Room Culling
+            {Function.Scene_DisableVisibilityGraph, 0x0044f800},
+            {Function.Scene_EnableAnimations, 0x0044f3a0}, //Animations when the game is/isn't in focus
+            {Function.Scene_DisableAnimations, 0x0044f3b0},
 
         };
 

--- a/testApp/Program.cs
+++ b/testApp/Program.cs
@@ -21,6 +21,8 @@ namespace testApp
 
             Injector i = new Injector(pHandle);
 
+            ObjManager om = new ObjManager(pHandle);
+
             uint playerServerId = getPlayerServerID(pHandle);
             uint playerClientId = getPlayerClientID(pHandle);
             uint lookingAtServerId = getLookingAtServerID(pHandle);
@@ -191,9 +193,9 @@ namespace testApp
 
             //Adapter.ShowPartySelection(pHandle, (int)PARTY_NPCS_K2.NPC_ATTON);
 
-            var player = Adapter.GetPlayerServerObject(pHandle);
+            //var player = Adapter.GetPlayerServerObject(pHandle);
 
-            SetAlignment(pHandle, player, 99);
+            //SetAlignment(pHandle, player, 99);
 
             //Adapter.SetPCInfluenceKotor2(pHandle, PARTY_NPCS_K2.NPC_ATTON, 0);
             //Console.WriteLine(Adapter.GetPCInfluenceKotor2(pHandle, PARTY_NPCS_K2.NPC_ATTON));
@@ -204,8 +206,8 @@ namespace testApp
 
             //Console.WriteLine($"Name: {Adapter.GetClientObjectName(pHandle, lookingAtClientId)}");
 
-            uint obj = Adapter.GetServerObject(pHandle, lookingAtServerId);
-            Console.WriteLine($"Server Tag: {getServerObjectTag(pHandle, obj)}");
+            //uint obj = Adapter.GetServerObject(pHandle, lookingAtServerId);
+            //Console.WriteLine($"Server Tag: {getServerObjectTag(pHandle, obj)}");
 
             //uint obj = Adapter.GetClientObject(pHandle, lookingAtClientId);
             //Console.WriteLine($"Client Tag: {getClientObjectTag(pHandle, obj)}");
@@ -221,8 +223,63 @@ namespace testApp
 
             //Adapter.ColorizeModel(pHandle, gob, 1f, 0f, 0f);
 
+            uint scene = getCurrentScene(pHandle);
+
+            //(float h, float s, float b) colorHsb = (0.0f, 0.5f, 1.0f);
+
+            //var colorRgb = HsbToRgb(colorHsb.h, colorHsb.s, colorHsb.b);
+
+            //uint color = om.createVector(colorRgb.r, colorRgb.g, colorRgb.b);
+
+            //float fogStart = 10.0f;
+            //float fogEnd = 60.0f;
+
+            //Thread.Sleep(7000);
+
+            //_ = i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_DisableAnimations])
+            //    .setThis(scene));
+
+            //_ = i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_EnableAnimations])
+            //    .setThis(scene));
+
+            //i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_SetFog])
+            //    .setThis(scene)
+            //    .addParam(1));
+
+            //i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_SetFogRange])
+            //   .setThis(scene)
+            //   .addParam(fogStart)
+            //   .addParam(fogEnd));
+
+            //while (true)
+            //{
+            //    Thread.Sleep(30);
+
+            //    colorHsb.h += 0.05f;
+            //    colorRgb = HsbToRgb(colorHsb.h, colorHsb.s, colorHsb.b);
+            //    om.setVector((IntPtr)color, colorRgb.r, colorRgb.g, colorRgb.b);
+
+            //    i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_SetFogColor])
+            //   .setThis(scene)
+            //   .addParam(color));
+            //}
+
+            //i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_DisableVisibilityGraph])
+            //   .setThis(scene));
+
+            //i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_EnableVisibilityGraph])
+            //   .setThis(scene));
+
+            //i.sendMessage(Examples.freeCam());
+
+            i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_SetSceneFocus])
+               .setThis(scene)
+               .addParam(175f)
+               .addParam(96f)
+               .addParam(0f));
+
             ////Console.WriteLine();
-            Console.ReadKey();
+            //Console.ReadKey();
 
         }
     }

--- a/testApp/Program.cs
+++ b/testApp/Program.cs
@@ -234,14 +234,6 @@ namespace testApp
             //float fogStart = 10.0f;
             //float fogEnd = 60.0f;
 
-            //Thread.Sleep(7000);
-
-            //_ = i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_DisableAnimations])
-            //    .setThis(scene));
-
-            //_ = i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_EnableAnimations])
-            //    .setThis(scene));
-
             //i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_SetFog])
             //    .setThis(scene)
             //    .addParam(1));
@@ -255,7 +247,7 @@ namespace testApp
             //{
             //    Thread.Sleep(30);
 
-            //    colorHsb.h += 0.05f;
+            //    colorHsb.h += 0.01f;
             //    colorRgb = HsbToRgb(colorHsb.h, colorHsb.s, colorHsb.b);
             //    om.setVector((IntPtr)color, colorRgb.r, colorRgb.g, colorRgb.b);
 
@@ -272,11 +264,6 @@ namespace testApp
 
             //i.sendMessage(Examples.freeCam());
 
-            i.runFunction(new RemoteFunction(funcLibrary[Function.Scene_SetSceneFocus])
-               .setThis(scene)
-               .addParam(175f)
-               .addParam(96f)
-               .addParam(0f));
 
             ////Console.WriteLine();
             //Console.ReadKey();


### PR DESCRIPTION
- fog adapters
    - `SetSceneFogOn(IntPtr pHandle, float rangeStart, float rangeEnd, float colorR = 0.5f, float colorG = 0.5f, float colorB = 0.5f)`
    - Enables Scene fog with this range and color
    - `SetSceneFogOff(IntPtr pHandle)`
    - Disables scene fog
- Visibility Graph (room culling) adapter
    - `SetVisibilityGraph(IntPtr pHandle, bool on)`
    - Allows you to turn Scene culling on/off
    - This allows all rooms to be visible in free-cam
- Color Helpers
    - `HsbToRgb` and `RgbToHsb` allow for easy conversion between Red/Green/Blue and Hue/Saturation/Brightness color schemes.
    -  Was used for the silly disco demo seen [here](https://www.youtube.com/watch?v=T0HRNZZUzKo)
- ObjManager `setVector`
    - Useful function for setting a vector stored in-game
    - This hints at a redesign I want to do with object manager, that allows for more robust tracking, reading, and writing of objects in game
- Other Func library functions